### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,3 +1,5 @@
+const {Container, Service, Image} = require("@quilt/quilt");
+
 // Specs for Node.js web service
 function Node(cfg) {
   if (typeof cfg.nWorker !== 'number') {

--- a/package.json
+++ b/package.json
@@ -1,3 +1,9 @@
 {
-    "main": "./node.js"
+  "name": "@quilt/nodejs",
+  "version": "0.0.1",
+  "main": "./node.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt"
+  }
 }


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.